### PR TITLE
Fix ruby 2.4.x compatibility issue

### DIFF
--- a/lib/acts_as_having_string_id/string_id.rb
+++ b/lib/acts_as_having_string_id/string_id.rb
@@ -57,7 +57,7 @@ module ActsAsHavingStringId
       end
 
       def deserialize(value)
-        if value.is_a?(String) || value.is_a?(Fixnum)
+        if value.is_a?(String) || value.class <= Integer
           ActsAsHavingStringId::StringId(@klass, value)
         elsif value == nil
           nil


### PR DESCRIPTION
Fixnum is deprecated in ruby 2.4.x. Here, we check whether a value is, or inherits from, Integer, instead of checking whether it's a Fixnum.

Fixes #15.