### PR TITLE
Fix range check

### DIFF
--- a/lib/acts_as_having_string_id/string_id.rb
+++ b/lib/acts_as_having_string_id/string_id.rb
@@ -39,21 +39,13 @@ module ActsAsHavingStringId
       other.is_a?(StringId) && other.int_value == int_value
     end
 
-    class Type < ActiveRecord::Type::Value
+    class Type < ActiveRecord::Type::Integer
       def initialize(klass)
         @klass = klass
       end
 
       def type
         :integer
-      end
-
-      def cast(value)
-        if value == nil
-          nil
-        else
-          ActsAsHavingStringId::StringId(@klass, value)
-        end
       end
 
       def deserialize(value)
@@ -72,6 +64,12 @@ module ActsAsHavingStringId
         else
           ActsAsHavingStringId::StringId(@klass, value).int_value
         end
+      end
+
+      private
+
+      def cast_value(value)
+        ActsAsHavingStringId::StringId(@klass, value)
       end
     end
   end

--- a/lib/acts_as_having_string_id/string_id.rb
+++ b/lib/acts_as_having_string_id/string_id.rb
@@ -45,10 +45,6 @@ module ActsAsHavingStringId
         @klass = klass
       end
 
-      def type
-        :integer
-      end
-
       def deserialize(value)
         if value.is_a?(String) || value.class <= Integer
           ActsAsHavingStringId::StringId(@klass, value)

--- a/lib/acts_as_having_string_id/string_id.rb
+++ b/lib/acts_as_having_string_id/string_id.rb
@@ -41,6 +41,7 @@ module ActsAsHavingStringId
 
     class Type < ActiveRecord::Type::Integer
       def initialize(klass)
+        super()
         @klass = klass
       end
 
@@ -59,11 +60,11 @@ module ActsAsHavingStringId
       end
 
       def serialize(value)
-        if value == nil
-          nil
-        else
-          ActsAsHavingStringId::StringId(@klass, value).int_value
+        result = cast(value)
+        if result
+          ensure_in_range(result.to_i)
         end
+        result
       end
 
       private

--- a/lib/acts_as_having_string_id/string_id.rb
+++ b/lib/acts_as_having_string_id/string_id.rb
@@ -48,10 +48,8 @@ module ActsAsHavingStringId
       def deserialize(value)
         if value.is_a?(String) || value.class <= Integer
           ActsAsHavingStringId::StringId(@klass, value)
-        elsif value == nil
-          nil
         else
-          super
+          value
         end
       end
 

--- a/test/acts_as_having_string_id_test.rb
+++ b/test/acts_as_having_string_id_test.rb
@@ -73,6 +73,13 @@ class ActsAsHavingStringId::Test < ActiveSupport::TestCase
     end
   end
 
+  test "serializing too large an id means range error" do
+    assert_raises ActiveModel::RangeError do
+      t = ActsAsHavingStringId::StringId::Type.new(AuthorWithStringId)
+      t.serialize(AuthorWithStringId.id_string(2**33))
+    end
+  end
+
   test "has_many/belongs_to relationship, both string id" do
     class Book1 < ApplicationRecord
       self.table_name = 'books'


### PR DESCRIPTION
Turns out attribute integer types must handle their own range check in order not to leave that part up to the database/database adapter.

Fixes #8 